### PR TITLE
Reduces signaling device cooldown from 2 seconds -> 0.5 seconds

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -63,7 +63,7 @@
 /obj/item/device/assembly/signaler/activate()
 	if(cooldown > 0)
 		return 0
-	cooldown = 2
+	cooldown = 0.5
 	spawn(10)
 		process_cooldown()
 


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
Reduces the signaling device cooldown to 0.5 seconds.
I noticed every time I tried to create a door-crushing button with a remote signaling device there was a mysterious force preventing me from pressing the button constantly. I assume this is to prevent server lag in some cases but a two second delay is really long. 

## Why it's good
Lets you do things that require constantly pressing the button.

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: Reduced the remote signaling device cooldown from 2 seconds to 0.5 seconds
